### PR TITLE
Feature/ssd write

### DIFF
--- a/src/main/java/SSD.java
+++ b/src/main/java/SSD.java
@@ -40,7 +40,10 @@ public class SSD {
             throw new SSDException(INVALID_COMMAND_MESSAGE);
         }
 
-        command.isValidCommand(commandOptionList);
+        if (command.isValidCommand(commandOptionList)) {
+            throw new SSDException(INVALID_COMMAND_MESSAGE);
+        }
+
         command.run(commandOptionList);
     }
 

--- a/src/main/java/SSD.java
+++ b/src/main/java/SSD.java
@@ -35,15 +35,17 @@ public class SSD {
         String commandStr = commandOptionList.get(0);
 
         SSDCommand command = SSDCommandFactory.of(commandStr);
-        if (isInvalidCommand(command, commandOptionList)) {
+
+        if (isInvalidCommand(command)) {
             throw new SSDException(INVALID_COMMAND_MESSAGE);
         }
 
+        command.isValidCommand(commandOptionList);
         command.run(commandOptionList);
     }
 
-    private static boolean isInvalidCommand(SSDCommand command, ArrayList<String> commandOptionList) {
-        return command == null || !command.isValidCommand(commandOptionList);
+    private static boolean isInvalidCommand(SSDCommand command) {
+        return command == null;
     }
 
     private static boolean isInvalidCommandLine(String commandLine) {

--- a/src/main/java/SSDReadCommand.java
+++ b/src/main/java/SSDReadCommand.java
@@ -11,12 +11,12 @@ public class SSDReadCommand implements SSDCommand {
     @Override
     public boolean isValidCommand(ArrayList<String> commandOptionList) {
         if (isInvalidLengthParameter(commandOptionList)) {
-            throw new SSDException(SSD.INVALID_LENGTH_PARAMETER_MESSAGE);
+            return false;
         }
 
         int pos = Integer.parseInt(commandOptionList.get(POS_INDEX));
         if (isIncorrectIndex(pos))
-            throw new SSDException(SSD.INVALID_INDEX_MESSAGE);
+            return false;
 
         return true;
     }

--- a/src/main/java/SSDReadCommand.java
+++ b/src/main/java/SSDReadCommand.java
@@ -23,9 +23,6 @@ public class SSDReadCommand implements SSDCommand {
 
     @Override
     public void run(ArrayList<String> commandOptionList) {
-        if(!isValidCommand(commandOptionList))
-            return;
-
         fileHandler.makeFile();
 
         int index = Integer.parseInt(commandOptionList.get(POS_INDEX));

--- a/src/main/java/SSDWriteCommand.java
+++ b/src/main/java/SSDWriteCommand.java
@@ -30,9 +30,6 @@ public class SSDWriteCommand implements SSDCommand {
 
     @Override
     public void run(ArrayList<String> commandOptionList) {
-        if (!isValidCommand(commandOptionList))
-            return;
-
         int pos = Integer.parseInt(commandOptionList.get(POS_INDEX));
         String value = commandOptionList.get(VALUE_INDEX);
 

--- a/src/main/java/SSDWriteCommand.java
+++ b/src/main/java/SSDWriteCommand.java
@@ -13,17 +13,17 @@ public class SSDWriteCommand implements SSDCommand {
     @Override
     public boolean isValidCommand(ArrayList<String> commandOptionList) {
         if (isInvalidLengthParameter(commandOptionList)) {
-            throw new SSDException(SSD.INVALID_LENGTH_PARAMETER_MESSAGE);
+            return false;
         }
 
         int pos = Integer.parseInt(commandOptionList.get(POS_INDEX));
         if (isIncorrectIndex(pos)) {
-            throw new SSDException(SSD.INVALID_INDEX_MESSAGE);
+            return false;
         }
 
         String value = commandOptionList.get(VALUE_INDEX);
         if (isIncorrectValue(value)) {
-            throw new SSDException(SSD.INVALID_VALUE_MESSAGE);
+            return false;
         }
         return true;
     }


### PR DESCRIPTION
[refactor] 
command 패턴의 run 수정

command 패턴의 run 수정
각 command의 run 수행 시 IsValidCommand 함수를 항상 위에서 작성하는데 이 코드는 강제성이 없기 때문에
개인의 실수로 IsValidCommand를 체크하지 않는 문제가 있습니다.
이를 SSD의 run에 반드시 command의 run 전에 수행하게 하도록 변경했습니다.
그렇게 저번 comment에서 언급한 레벨도 맞췄습니다.