### PR TITLE
[refactoring] Invalid command 조건 수정 (pareInt 에러 방지)

### DIFF
--- a/src/main/java/command/ssd/SSDEraseCommand.java
+++ b/src/main/java/command/ssd/SSDEraseCommand.java
@@ -19,26 +19,26 @@ public class SSDEraseCommand implements SSDCommand{
 
     @Override
     public boolean isValidCommand(ArrayList<String> commandOptionList) {
-        if (isInvalidLengthParameter(commandOptionList)) {
+        if (!isValidLengthParameter(commandOptionList)) {
             return false;
         }
 
-        if(isInvalidIntegerParameter(commandOptionList, POS_INDEX)) {
+        if(!isValidIntegerParameter(commandOptionList, POS_INDEX)) {
             return false;
         }
 
-        if(isInvalidIntegerParameter(commandOptionList, SIZE_INDEX)){
+        if(!isValidIntegerParameter(commandOptionList, SIZE_INDEX)){
             return false;
         }
 
         int pos = Integer.parseInt(commandOptionList.get(POS_INDEX));
         int size = Integer.parseInt(commandOptionList.get(SIZE_INDEX));
 
-        if (isIncorrectIndex(pos)) {
+        if (!isValidIndex(pos)) {
             return false;
         }
 
-        if (isIncorrectSize(size)) {
+        if (!isValidSize(size)) {
             return false;
         }
 
@@ -56,25 +56,21 @@ public class SSDEraseCommand implements SSDCommand{
         }
     }
 
-    private boolean isInvalidLengthParameter(ArrayList<String> commandOptionList) {
-        return commandOptionList == null || commandOptionList.size() != 3;
+    private boolean isValidLengthParameter(ArrayList<String> commandOptionList) {
+        return commandOptionList.size() == 3;
     }
 
-    private boolean isInvalidIntegerParameter(ArrayList<String> commandOptionList, int index){
+    private boolean isValidIntegerParameter(ArrayList<String> commandOptionList, int index){
         try{
             Integer.parseInt(commandOptionList.get(index));
-            return false;
-        } catch (NumberFormatException e){
             return true;
+        } catch (NumberFormatException e){
+            return false;
         }
     }
 
-    private boolean isIncorrectIndex(int index) {
-        return index < 0 || index > 99;
-    }
+    private boolean isValidIndex(int index) { return index >= 0 && index <= 99; }
 
-    private boolean isIncorrectSize(int size) {
-        return size < 1 || size > 10;
-    }
+    private boolean isValidSize(int size) { return size >= 1 && size <= 10; }
 
 }

--- a/src/main/java/command/ssd/SSDReadCommand.java
+++ b/src/main/java/command/ssd/SSDReadCommand.java
@@ -14,12 +14,16 @@ public class SSDReadCommand implements SSDCommand {
 
     @Override
     public boolean isValidCommand(ArrayList<String> commandOptionList) {
-        if (isInvalidLengthParameter(commandOptionList)) {
+        if (!isValidLengthParameter(commandOptionList)) {
+            return false;
+        }
+
+        if(!isValidIntegerParameter(commandOptionList, POS_INDEX)) {
             return false;
         }
 
         int pos = Integer.parseInt(commandOptionList.get(POS_INDEX));
-        if (isIncorrectIndex(pos))
+        if (!isValidIndex(pos))
             return false;
 
         return true;
@@ -34,11 +38,18 @@ public class SSDReadCommand implements SSDCommand {
         fileHandler.writeResult(index, data);
     }
 
-    private boolean isInvalidLengthParameter(ArrayList<String> commandOptionList) {
-        return commandOptionList == null || commandOptionList.size() != 2;
+    private boolean isValidLengthParameter(ArrayList<String> commandOptionList) {
+        return commandOptionList.size() == 2;
     }
 
-    private boolean isIncorrectIndex(int index) {
-        return index < 0 || index > 99;
+    private boolean isValidIntegerParameter(ArrayList<String> commandOptionList, int index){
+        try{
+            Integer.parseInt(commandOptionList.get(index));
+            return true;
+        } catch (NumberFormatException e){
+            return false;
+        }
     }
+
+    private boolean isValidIndex(int index) { return index >= 0 && index <= 99; }
 }

--- a/src/main/java/command/ssd/SSDWriteCommand.java
+++ b/src/main/java/command/ssd/SSDWriteCommand.java
@@ -18,17 +18,17 @@ public class SSDWriteCommand implements SSDCommand {
 
     @Override
     public boolean isValidCommand(ArrayList<String> commandOptionList) {
-        if (isInvalidLengthParameter(commandOptionList)) {
+        if (!isValidLengthParameter(commandOptionList)) {
             return false;
         }
 
         int pos = Integer.parseInt(commandOptionList.get(POS_INDEX));
-        if (isIncorrectIndex(pos)) {
+        if (!isValidIndex(pos)) {
             return false;
         }
 
         String value = commandOptionList.get(VALUE_INDEX);
-        if (isIncorrectValue(value)) {
+        if (!isValidValue(value)) {
             return false;
         }
         return true;
@@ -43,15 +43,13 @@ public class SSDWriteCommand implements SSDCommand {
         fileHandler.writeNAND(pos, value);
     }
 
-    private boolean isInvalidLengthParameter(ArrayList<String> commandOptionList) {
-        return commandOptionList.size() != 3;
+    private boolean isValidLengthParameter(ArrayList<String> commandOptionList) {
+        return commandOptionList.size() == 3;
     }
 
-    private boolean isIncorrectValue(String value) {
-        return value == null || value.isEmpty() || !value.matches(CORRECT_VALUE_REGEX);
+    private boolean isValidValue(String value) {
+        return value != null && !value.isEmpty() && value.matches(CORRECT_VALUE_REGEX);
     }
 
-    private boolean isIncorrectIndex(int pos) {
-        return pos < 0 || pos > 99;
-    }
+    private boolean isValidIndex(int index) { return index >= 0 && index <= 99; }
 }


### PR DESCRIPTION
ssd 명령어 입력 처리시에 Int 형식이 아닌 string이 들어왔을 때  INVALID COMMAND 반환 위해 수정하였습니다.
또한 함수명 isInvalid -> !isValid 로 rename 하였는데 확인 및 의견 부탁드립니다..!