### PR TITLE
[refactoring] Shell의 Invalid command 조건 수정 (pareInt 에러 방지)

### DIFF
--- a/src/main/java/command/shell/ShellEraseCommand.java
+++ b/src/main/java/command/shell/ShellEraseCommand.java
@@ -6,12 +6,12 @@ import app.SSD;
 public class ShellEraseCommand implements ShellCommand{
     @Override
     public boolean isValidCommand(ArrayList<String> commandOptionList) {
-        if(!isValidCommandOptionListSize(commandOptionList)){
-            return false;
-        }
-        if(!isValidIndex(commandOptionList)){
-            return false;
-        }
+        if(!isValidCommandOptionListSize(commandOptionList)) {return false;}
+
+        if(!isValidIntegerParameter(commandOptionList, 1)) {return false;}
+        if(!isValidIntegerParameter(commandOptionList, 2)) {return false;}
+
+        if(!isValidIndex(commandOptionList)) {return false;}
 
         return true;
     }
@@ -25,6 +25,15 @@ public class ShellEraseCommand implements ShellCommand{
 
     private boolean isValidCommandOptionListSize(ArrayList<String> commandOptionList) {
         return commandOptionList.size() == 3;
+    }
+
+    private boolean isValidIntegerParameter(ArrayList<String> commandOptionList, int index){
+        try{
+            Integer.parseInt(commandOptionList.get(index));
+            return true;
+        } catch (NumberFormatException e){
+            return false;
+        }
     }
 
     private boolean isValidIndex(ArrayList<String> commandOptionList) {

--- a/src/main/java/command/shell/ShellEraseRangeCommand.java
+++ b/src/main/java/command/shell/ShellEraseRangeCommand.java
@@ -7,12 +7,12 @@ import java.util.ArrayList;
 public class ShellEraseRangeCommand implements ShellCommand{
     @Override
     public boolean isValidCommand(ArrayList<String> commandOptionList) {
-        if(!isValidCommandOptionListSize(commandOptionList)){
-            return false;
-        }
-        if(!isValidIndex(commandOptionList)){
-            return false;
-        }
+        if(!isValidCommandOptionListSize(commandOptionList)) {return false;}
+
+        if(!isValidIntegerParameter(commandOptionList, 1)) {return false;}
+        if(!isValidIntegerParameter(commandOptionList, 2)) {return false;}
+
+        if(!isValidIndex(commandOptionList)) {return false;}
 
         return true;
     }
@@ -32,6 +32,15 @@ public class ShellEraseRangeCommand implements ShellCommand{
 
     private boolean isValidCommandOptionListSize(ArrayList<String> commandOptionList) {
         return commandOptionList.size() == 3;
+    }
+
+    private boolean isValidIntegerParameter(ArrayList<String> commandOptionList, int index){
+        try{
+            Integer.parseInt(commandOptionList.get(index));
+            return true;
+        } catch (NumberFormatException e){
+            return false;
+        }
     }
 
     private boolean isValidIndex(ArrayList<String> commandOptionList) {

--- a/src/main/java/command/shell/ShellReadCommand.java
+++ b/src/main/java/command/shell/ShellReadCommand.java
@@ -7,11 +7,11 @@ import java.util.ArrayList;
 public class ShellReadCommand implements ShellCommand {
     @Override
     public boolean isValidCommand(ArrayList<String> commandOptionList) {
-        if (!isValidCommandOptionListSize(commandOptionList))
-            return false;
+        if(!isValidCommandOptionListSize(commandOptionList)) {return false;}
 
-        if (!isValidIndex(commandOptionList))
-            return false;
+        if(!isValidIntegerParameter(commandOptionList, 1)) {return false;}
+
+        if(!isValidIndex(commandOptionList)) { return false;}
 
         return true;
     }
@@ -23,6 +23,15 @@ public class ShellReadCommand implements ShellCommand {
 
     public boolean isValidCommandOptionListSize(ArrayList<String> commandOptionList) {
         return commandOptionList.size() == 2;
+    }
+
+    private boolean isValidIntegerParameter(ArrayList<String> commandOptionList, int index){
+        try{
+            Integer.parseInt(commandOptionList.get(index));
+            return true;
+        } catch (NumberFormatException e){
+            return false;
+        }
     }
 
     private boolean isValidIndex(ArrayList<String> commandOptionList) {

--- a/src/main/java/command/shell/ShellRunnerCommand.java
+++ b/src/main/java/command/shell/ShellRunnerCommand.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 public class ShellRunnerCommand implements ShellCommand {
     @Override
     public boolean isValidCommand(ArrayList<String> commandOptionList) {
-        if (!isValidCommandSize(commandOptionList))
+        if(!isValidCommandSize(commandOptionList))
             return false;
 
         return true;

--- a/src/main/java/command/shell/ShellTestApp1Command.java
+++ b/src/main/java/command/shell/ShellTestApp1Command.java
@@ -12,7 +12,7 @@ public class ShellTestApp1Command implements ShellCommand {
 
     @Override
     public boolean isValidCommand(ArrayList<String> commandOptionList) {
-        if (!isValidCommandOptionListSize(commandOptionList)) {
+        if(!isValidCommandOptionListSize(commandOptionList)) {
             return false;
         }
         return true;

--- a/src/main/java/command/shell/ShellWriteCommand.java
+++ b/src/main/java/command/shell/ShellWriteCommand.java
@@ -7,12 +7,9 @@ import java.util.ArrayList;
 public class ShellWriteCommand implements ShellCommand{
     @Override
     public boolean isValidCommand(ArrayList<String> commandOptionList) {
-        if(!isValidCommandOptionListSize(commandOptionList)){
-            return false;
-        }
-        if(!isValidIndex(commandOptionList)){
-            return false;
-        }
+        if(!isValidCommandOptionListSize(commandOptionList)) {return false;}
+        if(!isValidIntegerParameter(commandOptionList, 1)) {return false;}
+        if(!isValidIndex(commandOptionList)) {return false;}
 
         return true;
     }
@@ -24,6 +21,15 @@ public class ShellWriteCommand implements ShellCommand{
 
     private boolean isValidCommandOptionListSize(ArrayList<String> commandOptionList) {
         return commandOptionList.size() == 3;
+    }
+
+    private boolean isValidIntegerParameter(ArrayList<String> commandOptionList, int index){
+        try{
+            Integer.parseInt(commandOptionList.get(index));
+            return true;
+        } catch (NumberFormatException e){
+            return false;
+        }
     }
 
     private boolean isValidIndex(ArrayList<String> commandOptionList) {

--- a/src/main/java/command/ssd/SSDEraseCommand.java
+++ b/src/main/java/command/ssd/SSDEraseCommand.java
@@ -19,28 +19,16 @@ public class SSDEraseCommand implements SSDCommand{
 
     @Override
     public boolean isValidCommand(ArrayList<String> commandOptionList) {
-        if (!isValidLengthParameter(commandOptionList)) {
-            return false;
-        }
+        if(!isValidLengthParameter(commandOptionList)) {return false;}
 
-        if(!isValidIntegerParameter(commandOptionList, POS_INDEX)) {
-            return false;
-        }
-
-        if(!isValidIntegerParameter(commandOptionList, SIZE_INDEX)){
-            return false;
-        }
+        if(!isValidIntegerParameter(commandOptionList, POS_INDEX)) {return false;}
+        if(!isValidIntegerParameter(commandOptionList, SIZE_INDEX)){return false;}
 
         int pos = Integer.parseInt(commandOptionList.get(POS_INDEX));
         int size = Integer.parseInt(commandOptionList.get(SIZE_INDEX));
 
-        if (!isValidIndex(pos)) {
-            return false;
-        }
-
-        if (!isValidSize(size)) {
-            return false;
-        }
+        if(!isValidIndex(pos)) {return false;}
+        if(!isValidSize(size)) {return false;}
 
         return true;
     }

--- a/src/main/java/command/ssd/SSDReadCommand.java
+++ b/src/main/java/command/ssd/SSDReadCommand.java
@@ -14,17 +14,12 @@ public class SSDReadCommand implements SSDCommand {
 
     @Override
     public boolean isValidCommand(ArrayList<String> commandOptionList) {
-        if (!isValidLengthParameter(commandOptionList)) {
-            return false;
-        }
+        if(!isValidLengthParameter(commandOptionList)) {return false;}
 
-        if(!isValidIntegerParameter(commandOptionList, POS_INDEX)) {
-            return false;
-        }
+        if(!isValidIntegerParameter(commandOptionList, POS_INDEX)) {return false;}
 
         int pos = Integer.parseInt(commandOptionList.get(POS_INDEX));
-        if (!isValidIndex(pos))
-            return false;
+        if(!isValidIndex(pos)) {return false;}
 
         return true;
     }

--- a/src/main/java/command/ssd/SSDWriteCommand.java
+++ b/src/main/java/command/ssd/SSDWriteCommand.java
@@ -18,19 +18,15 @@ public class SSDWriteCommand implements SSDCommand {
 
     @Override
     public boolean isValidCommand(ArrayList<String> commandOptionList) {
-        if (!isValidLengthParameter(commandOptionList)) {
-            return false;
-        }
+        if(!isValidLengthParameter(commandOptionList)) {return false;}
+
+        if(!isValidIntegerParameter(commandOptionList, POS_INDEX)) {return false;}
 
         int pos = Integer.parseInt(commandOptionList.get(POS_INDEX));
-        if (!isValidIndex(pos)) {
-            return false;
-        }
+        if(!isValidIndex(pos)) {return false;}
 
         String value = commandOptionList.get(VALUE_INDEX);
-        if (!isValidValue(value)) {
-            return false;
-        }
+        if(!isValidValue(value)) {return false;}
         return true;
     }
 
@@ -47,9 +43,18 @@ public class SSDWriteCommand implements SSDCommand {
         return commandOptionList.size() == 3;
     }
 
-    private boolean isValidValue(String value) {
-        return value != null && !value.isEmpty() && value.matches(CORRECT_VALUE_REGEX);
+    private boolean isValidIntegerParameter(ArrayList<String> commandOptionList, int index){
+        try{
+            Integer.parseInt(commandOptionList.get(index));
+            return true;
+        } catch (NumberFormatException e){
+            return false;
+        }
     }
 
     private boolean isValidIndex(int index) { return index >= 0 && index <= 99; }
+
+    private boolean isValidValue(String value) {
+        return value != null && !value.isEmpty() && value.matches(CORRECT_VALUE_REGEX);
+    }
 }


### PR DESCRIPTION
Shell 명령어 입력 처리시에 Int 형식이 아닌 string이 들어왔을 때 INVALID COMMAND 반환 위해 수정하였습니다.
SSDTest, ShellTest 코드 PASS 확인했습니다.
확인 및 피드백 부탁드립니다