### PR TITLE
[refactor] SSD의 command parameter의 validation 체크 공통 부분 extract

### DIFF
--- a/src/main/java/command/ssd/SSDEraseCommand.java
+++ b/src/main/java/command/ssd/SSDEraseCommand.java
@@ -11,6 +11,7 @@ public class SSDEraseCommand implements SSDCommand{
 
     private static final Integer POS_INDEX = 1;
     private static final Integer SIZE_INDEX = 2;
+    private static final Integer COMMAND_OPTION_LIST_LENGTH = 3;
 
     FileHandler fileHandler;
 
@@ -20,7 +21,7 @@ public class SSDEraseCommand implements SSDCommand{
 
     @Override
     public boolean isValidCommand(ArrayList<String> commandOptionList) {
-        if(!CommandValidation.isValidLengthParameter(commandOptionList, 3)) {return false;}
+        if(!CommandValidation.isValidLengthParameter(commandOptionList, COMMAND_OPTION_LIST_LENGTH)) {return false;}
 
         if(!CommandValidation.isValidIntegerParameter(commandOptionList, POS_INDEX)) {return false;}
         if(!CommandValidation.isValidIntegerParameter(commandOptionList, SIZE_INDEX)){return false;}

--- a/src/main/java/command/ssd/SSDEraseCommand.java
+++ b/src/main/java/command/ssd/SSDEraseCommand.java
@@ -1,6 +1,7 @@
 package command.ssd;
 
 import util.FileHandler;
+import util.CommandValidation;
 
 import java.util.ArrayList;
 
@@ -19,16 +20,13 @@ public class SSDEraseCommand implements SSDCommand{
 
     @Override
     public boolean isValidCommand(ArrayList<String> commandOptionList) {
-        if(!isValidLengthParameter(commandOptionList)) {return false;}
+        if(!CommandValidation.isValidLengthParameter(commandOptionList, 3)) {return false;}
 
-        if(!isValidIntegerParameter(commandOptionList, POS_INDEX)) {return false;}
-        if(!isValidIntegerParameter(commandOptionList, SIZE_INDEX)){return false;}
+        if(!CommandValidation.isValidIntegerParameter(commandOptionList, POS_INDEX)) {return false;}
+        if(!CommandValidation.isValidIntegerParameter(commandOptionList, SIZE_INDEX)){return false;}
 
-        int pos = Integer.parseInt(commandOptionList.get(POS_INDEX));
-        int size = Integer.parseInt(commandOptionList.get(SIZE_INDEX));
-
-        if(!isValidIndex(pos)) {return false;}
-        if(!isValidSize(size)) {return false;}
+        if(!CommandValidation.isValidIndex(commandOptionList, POS_INDEX)) {return false;}
+        if(!CommandValidation.isValidEraseSize(commandOptionList, SIZE_INDEX)) {return false;}
 
         return true;
     }
@@ -43,22 +41,4 @@ public class SSDEraseCommand implements SSDCommand{
             fileHandler.writeNAND(index, DEFAULT_VALUE);
         }
     }
-
-    private boolean isValidLengthParameter(ArrayList<String> commandOptionList) {
-        return commandOptionList.size() == 3;
-    }
-
-    private boolean isValidIntegerParameter(ArrayList<String> commandOptionList, int index){
-        try{
-            Integer.parseInt(commandOptionList.get(index));
-            return true;
-        } catch (NumberFormatException e){
-            return false;
-        }
-    }
-
-    private boolean isValidIndex(int index) { return index >= 0 && index <= 99; }
-
-    private boolean isValidSize(int size) { return size >= 1 && size <= 10; }
-
 }

--- a/src/main/java/command/ssd/SSDReadCommand.java
+++ b/src/main/java/command/ssd/SSDReadCommand.java
@@ -7,6 +7,8 @@ import java.util.ArrayList;
 
 public class SSDReadCommand implements SSDCommand {
     private static final Integer POS_INDEX = 1;
+    private static final Integer COMMAND_OPTION_LIST_LENGTH = 2;
+
     FileHandler fileHandler;
 
     public SSDReadCommand(){
@@ -15,7 +17,7 @@ public class SSDReadCommand implements SSDCommand {
 
     @Override
     public boolean isValidCommand(ArrayList<String> commandOptionList) {
-        if(!CommandValidation.isValidLengthParameter(commandOptionList, 2)) {return false;}
+        if(!CommandValidation.isValidLengthParameter(commandOptionList, COMMAND_OPTION_LIST_LENGTH)) {return false;}
 
         if(!CommandValidation.isValidIntegerParameter(commandOptionList, POS_INDEX)) {return false;}
 

--- a/src/main/java/command/ssd/SSDReadCommand.java
+++ b/src/main/java/command/ssd/SSDReadCommand.java
@@ -1,5 +1,6 @@
 package command.ssd;
 
+import util.CommandValidation;
 import util.FileHandler;
 
 import java.util.ArrayList;
@@ -14,12 +15,11 @@ public class SSDReadCommand implements SSDCommand {
 
     @Override
     public boolean isValidCommand(ArrayList<String> commandOptionList) {
-        if(!isValidLengthParameter(commandOptionList)) {return false;}
+        if(!CommandValidation.isValidLengthParameter(commandOptionList, 2)) {return false;}
 
-        if(!isValidIntegerParameter(commandOptionList, POS_INDEX)) {return false;}
+        if(!CommandValidation.isValidIntegerParameter(commandOptionList, POS_INDEX)) {return false;}
 
-        int pos = Integer.parseInt(commandOptionList.get(POS_INDEX));
-        if(!isValidIndex(pos)) {return false;}
+        if(!CommandValidation.isValidIndex(commandOptionList, POS_INDEX)) {return false;}
 
         return true;
     }
@@ -32,19 +32,4 @@ public class SSDReadCommand implements SSDCommand {
         String data = fileHandler.readNAND(index);
         fileHandler.writeResult(index, data);
     }
-
-    private boolean isValidLengthParameter(ArrayList<String> commandOptionList) {
-        return commandOptionList.size() == 2;
-    }
-
-    private boolean isValidIntegerParameter(ArrayList<String> commandOptionList, int index){
-        try{
-            Integer.parseInt(commandOptionList.get(index));
-            return true;
-        } catch (NumberFormatException e){
-            return false;
-        }
-    }
-
-    private boolean isValidIndex(int index) { return index >= 0 && index <= 99; }
 }

--- a/src/main/java/command/ssd/SSDWriteCommand.java
+++ b/src/main/java/command/ssd/SSDWriteCommand.java
@@ -1,5 +1,6 @@
 package command.ssd;
 
+import util.CommandValidation;
 import util.FileHandler;
 
 import java.util.ArrayList;
@@ -8,7 +9,6 @@ public class SSDWriteCommand implements SSDCommand {
     private static final Integer POS_INDEX = 1;
     private static final Integer VALUE_INDEX = 2;
 
-    public static final String CORRECT_VALUE_REGEX = "^0x[0-9A-F]{8}$";
 
     FileHandler fileHandler;
 
@@ -18,15 +18,13 @@ public class SSDWriteCommand implements SSDCommand {
 
     @Override
     public boolean isValidCommand(ArrayList<String> commandOptionList) {
-        if(!isValidLengthParameter(commandOptionList)) {return false;}
+        if(!CommandValidation.isValidLengthParameter(commandOptionList, 3)) {return false;}
 
-        if(!isValidIntegerParameter(commandOptionList, POS_INDEX)) {return false;}
+        if(!CommandValidation.isValidIntegerParameter(commandOptionList, POS_INDEX)) {return false;}
 
-        int pos = Integer.parseInt(commandOptionList.get(POS_INDEX));
-        if(!isValidIndex(pos)) {return false;}
+        if(!CommandValidation.isValidIndex(commandOptionList, POS_INDEX)) {return false;}
 
-        String value = commandOptionList.get(VALUE_INDEX);
-        if(!isValidValue(value)) {return false;}
+        if(!CommandValidation.isValidValue(commandOptionList, VALUE_INDEX)) {return false;}
         return true;
     }
 
@@ -39,22 +37,4 @@ public class SSDWriteCommand implements SSDCommand {
         fileHandler.writeNAND(pos, value);
     }
 
-    private boolean isValidLengthParameter(ArrayList<String> commandOptionList) {
-        return commandOptionList.size() == 3;
-    }
-
-    private boolean isValidIntegerParameter(ArrayList<String> commandOptionList, int index){
-        try{
-            Integer.parseInt(commandOptionList.get(index));
-            return true;
-        } catch (NumberFormatException e){
-            return false;
-        }
-    }
-
-    private boolean isValidIndex(int index) { return index >= 0 && index <= 99; }
-
-    private boolean isValidValue(String value) {
-        return value != null && !value.isEmpty() && value.matches(CORRECT_VALUE_REGEX);
-    }
 }

--- a/src/main/java/command/ssd/SSDWriteCommand.java
+++ b/src/main/java/command/ssd/SSDWriteCommand.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 public class SSDWriteCommand implements SSDCommand {
     private static final Integer POS_INDEX = 1;
     private static final Integer VALUE_INDEX = 2;
-
+    private static final Integer COMMAND_OPTION_LIST_LENGTH = 3;
 
     FileHandler fileHandler;
 
@@ -18,7 +18,7 @@ public class SSDWriteCommand implements SSDCommand {
 
     @Override
     public boolean isValidCommand(ArrayList<String> commandOptionList) {
-        if(!CommandValidation.isValidLengthParameter(commandOptionList, 3)) {return false;}
+        if(!CommandValidation.isValidLengthParameter(commandOptionList, COMMAND_OPTION_LIST_LENGTH)) {return false;}
 
         if(!CommandValidation.isValidIntegerParameter(commandOptionList, POS_INDEX)) {return false;}
 

--- a/src/main/java/util/CommandValidation.java
+++ b/src/main/java/util/CommandValidation.java
@@ -1,0 +1,44 @@
+package util;
+
+import java.util.ArrayList;
+
+public class CommandValidation {
+
+    public static final String CORRECT_VALUE_REGEX = "^0x[0-9A-F]{8}$";
+
+    public static boolean isValidLengthParameter(ArrayList<String> commandOptionList, int length) {
+        return commandOptionList.size() == length;
+    }
+
+    public static boolean isValidIntegerParameter(ArrayList<String> commandOptionList, int index){
+        try{
+            Integer.parseInt(commandOptionList.get(index));
+            return true;
+        } catch (NumberFormatException e){
+            return false;
+        }
+    }
+
+    public static boolean isValidIndex(ArrayList<String> commandOptionList, int commandIndex) {
+        try{
+            int index = Integer.parseInt(commandOptionList.get(commandIndex));
+            return index >= 0 && index <= 99;
+        } catch (NumberFormatException e){
+            return false;
+        }
+    }
+
+    public static boolean isValidValue(ArrayList<String> commandOptionList, int commandIndex) {
+        String value = commandOptionList.get(commandIndex);
+        return value != null && !value.isEmpty() && value.matches(CORRECT_VALUE_REGEX);
+    }
+
+    public static boolean isValidEraseSize(ArrayList<String> commandOptionList, int commandIndex) {
+        try{
+            int size = Integer.parseInt(commandOptionList.get(commandIndex));
+            return size >= 1 && size <= 10;
+        } catch (NumberFormatException e){
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
SSD 명령어 파라미터 입력시, 파라미터의 validation 체크하는 메소드가 공통된 부분이 많아서 
util -> CommandValidation 클래스로 공통 부분을 extract 하였습니다.
공통으로 추출한 validation 체크 메소드는 아래와 같습니다

- 함수 파라미터 개수 확인
- Integer 타입 파라미터가 맞는지 확인 (LBA, Erase SIZE 등)
- LBA 범위 체크 : 0~99, 10진수
- Write 시 값의 4Byte 형식 체크
- Erase 시 SIZE 범위 체크 : 1~10, 10진수

현재 SSD까지 작업했고 피드백 반영 후 Shell 부분도 작업 하려고 하는데 의견 부탁드립니다~
